### PR TITLE
[fix] Fixed missed <climits> in Horspool.cpp

### DIFF
--- a/Horspool.cpp
+++ b/Horspool.cpp
@@ -26,6 +26,7 @@
 
 #include <vector>
 #include <cstring>
+#include <climits>
  
 typedef std::vector<size_t> occtable_type;
 


### PR DESCRIPTION
Without it building fails on Linux.
