### PR TITLE
[fix] Replacing ssize_t -> int

### DIFF
--- a/BoyerMooreAndTurbo.cpp
+++ b/BoyerMooreAndTurbo.cpp
@@ -41,18 +41,18 @@ const skiptable_type
  
     const size_t needle_length_minus_1 = needle_length-1;
  
-    std::vector<ssize_t> suff(needle_length);
+    std::vector<int> suff(needle_length);
  
     suff[needle_length_minus_1] = needle_length;
  
-    ssize_t f = 0;
-    ssize_t g = needle_length_minus_1;
+    int f = 0;
+    int g = needle_length_minus_1;
     size_t j = 0; // index for writing into skip[]
-    for(ssize_t i = needle_length-2; i >= 0; --i) // For each suffix length
+    for(int i = needle_length-2; i >= 0; --i) // For each suffix length
     {
         if(i > g)
         {
-            const ssize_t tmp = suff[i + needle_length_minus_1 - f];
+            const int tmp = suff[i + needle_length_minus_1 - f];
             if (tmp < i - g)
             {
                 suff[i] = tmp;
@@ -131,8 +131,8 @@ size_t SearchIn(const unsigned char* haystack, size_t haystack_length,
  
         const unsigned char occ_char = haystack[haystack_position + mismatch_position];
  
-        const ssize_t bcShift = occ[occ_char] - match_len;
-        const ssize_t gcShift = skip[mismatch_position];
+        const int bcShift = occ[occ_char] - match_len;
+        const int gcShift = skip[mismatch_position];
  
         size_t shift = std::max(gcShift, bcShift);
  
@@ -204,11 +204,11 @@ size_t SearchInTurbo(const unsigned char* haystack, size_t haystack_length,
  
         const unsigned char occ_char = haystack[haystack_position + mismatch_position];
  
-        const ssize_t bcShift = occ[occ_char] - match_len;
+        const int bcShift = occ[occ_char] - match_len;
         const size_t gcShift  = skip[mismatch_position];
-        const ssize_t turboShift = ignore_num - match_len;
+        const int turboShift = ignore_num - match_len;
  
-        shift = std::max(std::max((ssize_t)gcShift, bcShift), turboShift);
+        shift = std::max(std::max((int)gcShift, bcShift), turboShift);
  
         if(shift == gcShift)
             ignore_num = std::min( needle_length - shift, match_len);

--- a/StreamBoyerMooreHorspool.h
+++ b/StreamBoyerMooreHorspool.h
@@ -302,7 +302,7 @@ sbmh_init(struct StreamBMH *restrict ctx, struct StreamBMH_Occ *restrict occ,
 
 inline char
 sbmh_lookup_char(const struct StreamBMH *restrict ctx,
-	const unsigned char *restrict data, ssize_t pos)
+	const unsigned char *restrict data, int pos)
 {
 	if (pos < 0) {
 		return _SBMH_LOOKBEHIND(ctx)[ctx->lookbehind_size + pos];
@@ -315,11 +315,11 @@ inline bool
 sbmh_memcmp(const struct StreamBMH *restrict ctx,
 	const unsigned char *restrict needle,
 	const unsigned char *restrict data,
-	ssize_t pos, sbmh_size_t len)
+	int pos, sbmh_size_t len)
 {
-	ssize_t i = 0;
+	int i = 0;
 	
-	while (i < ssize_t(len)) {
+	while (i < int(len)) {
 		unsigned char data_ch = sbmh_lookup_char(ctx, data, pos + i);
 		unsigned char needle_ch = needle[i];
 		
@@ -348,7 +348,7 @@ sbmh_feed(struct StreamBMH *restrict ctx, const struct StreamBMH_Occ *restrict o
 	 * Negative: points to a position in the lookbehind buffer
 	 *           pos == -2 points to lookbehind[lookbehind_size - 2]
 	 */
-	ssize_t pos = -ctx->lookbehind_size;
+	int pos = -ctx->lookbehind_size;
 	unsigned char last_needle_char = needle[needle_len - 1];
 	const sbmh_size_t *occ = occtable->occ;
 	unsigned char *lookbehind = _SBMH_LOOKBEHIND(ctx);
@@ -371,7 +371,7 @@ sbmh_feed(struct StreamBMH *restrict ctx, const struct StreamBMH_Occ *restrict o
 		 * or until
 		 *   the character to look at lies outside the haystack.
 		 */
-		while (pos < 0 && pos <= ssize_t(len) - ssize_t(needle_len)) {
+		while (pos < 0 && pos <= int(len) - int(needle_len)) {
 			 unsigned char ch = sbmh_lookup_char(ctx, data,
 				pos + needle_len - 1);
 			
@@ -422,7 +422,7 @@ sbmh_feed(struct StreamBMH *restrict ctx, const struct StreamBMH_Occ *restrict o
 			 * been processed and append the entire haystack
 			 * into it.
 			 */
-			sbmh_size_t bytesToCutOff = sbmh_size_t(ssize_t(ctx->lookbehind_size) + pos);
+			sbmh_size_t bytesToCutOff = sbmh_size_t(int(ctx->lookbehind_size) + pos);
 			
 			if (bytesToCutOff > 0 && ctx->callback != NULL) {
 				// The cut off data is guaranteed not to contain the needle.
@@ -434,7 +434,7 @@ sbmh_feed(struct StreamBMH *restrict ctx, const struct StreamBMH_Occ *restrict o
 				ctx->lookbehind_size - bytesToCutOff);
 			ctx->lookbehind_size -= bytesToCutOff;
 			
-			assert(ssize_t(ctx->lookbehind_size + len) < ssize_t(needle_len));
+			assert(int(ctx->lookbehind_size + len) < int(needle_len));
 			memcpy(lookbehind + ctx->lookbehind_size,
 				data, len);
 			ctx->lookbehind_size += len;
@@ -454,7 +454,7 @@ sbmh_feed(struct StreamBMH *restrict ctx, const struct StreamBMH_Occ *restrict o
 	 * search with optimized character lookup code that only considers
 	 * the current round's haystack data.
 	 */
-	while (likely( pos <= ssize_t(len) - ssize_t(needle_len) )) {
+	while (likely( pos <= int(len) - int(needle_len) )) {
 		unsigned char ch = data[pos + needle_len - 1];
 		
 		if (unlikely(

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -33,7 +33,7 @@ memmem2(const char *haystack, size_t haystack_len, const char *needle, size_t ne
 			} else if (memcmp(result, needle, needle_len) == 0) {
 				return result;
 			} else {
-				ssize_t new_len = ssize_t(haystack_len) - (result - haystack) - 1;
+				int new_len = int(haystack_len) - (result - haystack) - 1;
 				if (new_len <= 0) {
 					return NULL;
 				} else {


### PR DESCRIPTION
ssize_t is not standard ISO type. I think, you should use int instead of ssize_t.
